### PR TITLE
Add Test::META to test-depends

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -11,6 +11,6 @@
   "resources" : [ ],
   "source-url" : "https://github.com/mryan/perl6-Slang-AltTernary.git",
   "tags" : [ "Slang" , "Grammar" ],
-  "test-depends" : [ "Test" ],
+  "test-depends" : [ "Test", "Test::META" ],
   "version" : "0.0.3"
 }


### PR DESCRIPTION
Otherwise installation fails for users who don't
have Test::META installed.